### PR TITLE
Allow custom-dashboards to be deployed into any namespace

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -3,13 +3,13 @@ openshift_cluster_content:
     content:
       - name: Software Delivery Metrics Dashboard
         file: "{{ inventory_dir }}/../dashboard-sdm.yml"
-        namespace: "openshift-monitoring"
+        namespace: "tph-monitoring"
         tags:
           - dashboard-sdm
       - name: Mount Software Delivery Dashboard to Grafana
         action: patch
         file: "{{ inventory_dir }}/../grafana-deployment.yml"
         params: "{{ inventory_dir }}/../sdm-volume-patch.yml"
-        namespace: "openshift-monitoring"
+        namespace: "tph-monitoring"
         tags:
           - dashboard-sdm

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -1,15 +1,16 @@
+dashboard_namespace: tph-monitoring
 openshift_cluster_content:
   - object: Dashboards - DevOps
     content:
       - name: Software Delivery Metrics Dashboard
         file: "{{ inventory_dir }}/../dashboard-sdm.yml"
-        namespace: "tph-monitoring"
+        namespace: "{{ dashboard_namespace }}"
         tags:
           - dashboard-sdm
       - name: Mount Software Delivery Dashboard to Grafana
         action: patch
         file: "{{ inventory_dir }}/../grafana-deployment.yml"
         params: "{{ inventory_dir }}/../sdm-volume-patch.yml"
-        namespace: "tph-monitoring"
+        namespace: "{{ dashboard_namespace }}"
         tags:
           - dashboard-sdm

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -1,4 +1,4 @@
-dashboard_namespace: tph-monitoring
+dashboard_namespace: openshift-monitoring
 openshift_cluster_content:
   - object: Dashboards - DevOps
     content:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Execute the following command to provision the tool:
 ansible-galaxy install -r requirements.yml -p galaxy
 
 # Install prerequisite infrastructure
-ansible-playbook -i galaxy/openshift-toolkit/custom-dashboards/.applier galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e include_tags=infrastructure
+ansible-playbook -i galaxy/openshift-toolkit/custom-dashboards/.applier galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e include_tags=infrastructure  -e dashboard_namespace=tph2-monitoring
 
 # Deploy MDT Tool
-ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
+ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml  -e dashboard_namespace=tph2-monitoring
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Execute the following command to provision the tool:
 ansible-galaxy install -r requirements.yml -p galaxy
 
 # Install prerequisite infrastructure
-ansible-playbook -i galaxy/openshift-toolkit/custom-dashboards/.appler galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e include_tags=infrastructure
+ansible-playbook -i galaxy/openshift-toolkit/custom-dashboards/.applier galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e include_tags=infrastructure
 
 # Deploy MDT Tool
 ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml

--- a/grafana-deployment.yml
+++ b/grafana-deployment.yml
@@ -89,8 +89,8 @@ spec:
       nodeSelector:
         #This allowed the code to deploy in a different namespace, not sure how to get
         #regular namespaces to deploy to infranodes yet
-        #node-role.kubernetes.io/infra: "true"
-        node-role.kubernetes.io/compute: "true"
+        node-role.kubernetes.io/infra: "true"
+        #node-role.kubernetes.io/compute: "true"
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}

--- a/grafana-deployment.yml
+++ b/grafana-deployment.yml
@@ -87,7 +87,10 @@ spec:
           name: secret-grafana-proxy
       dnsPolicy: ClusterFirst
       nodeSelector:
-        node-role.kubernetes.io/infra: "true"
+        #This allowed the code to deploy in a different namespace, not sure how to get
+        #regular namespaces to deploy to infranodes yet
+        #node-role.kubernetes.io/infra: "true"
+        node-role.kubernetes.io/compute: "true"
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
   version: v2.1.1
-- src: https://github.com/redhat-cop/openshift-toolkit
-  version: master
+- src: https://github.com/ramius345/openshift-toolkit
+  version: manual_namespace

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,4 +2,4 @@
 - src: https://github.com/redhat-cop/openshift-applier
   version: v2.1.1
 - src: https://github.com/ramius345/openshift-toolkit
-  version: manual_namespace
+  version: namespace_mods


### PR DESCRIPTION
This is to allow the mdt-quickstart project to deploy to a different namespace.