### PR TITLE
Add: GitHub Commit Time Exporter

### DIFF
--- a/metrics-exporters/commit-time-exporter/Dockerfile
+++ b/metrics-exporters/commit-time-exporter/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.8-slim
+#FROM registry.redhat.io/ubi8/python-36
+
+MAINTAINER Aly Ibrahim<aly@redhat.com>
+
+RUN mkdir -p exporter
+
+COPY requirements.txt exporter/
+
+RUN pip install --no-cache-dir -r exporter/requirements.txt
+
+COPY commits-exporter.py exporter/
+
+EXPOSE 9118
+
+ENTRYPOINT ["python", "exporter/commits-exporter.py" ]
+
+

--- a/metrics-exporters/commit-time-exporter/commits-exporter.py
+++ b/metrics-exporters/commit-time-exporter/commits-exporter.py
@@ -1,0 +1,54 @@
+import os
+import json
+import time
+import requests
+from datetime import datetime
+from prometheus_client import start_http_server
+from prometheus_client.core import CounterMetricFamily,InfoMetricFamily,GaugeMetricFamily, REGISTRY
+
+class CommitCollector(object):
+    _prefix = "https://api.github.com/repos/"
+    _suffix = "/commits"
+    def __init__(self, username, token, repos):
+        self._username = username
+        self._token = token
+        self._repos = repos
+        self._urls = generate_urls(repos)
+    def collect(self):
+        metric = GaugeMetricFamily('github_commit_timestamp', 'Commit timestamp', labels=['repo', 'commit_hash'])
+        for repo in self._repos:
+            url = self._prefix + repo.strip() + self._suffix
+            print(url)
+            response = requests.get(url, auth=(self._username, self._token))
+            result = response.json()
+            for commit in result:
+                print(commit)
+                message = commit['commit']['message']
+                commit_hash = commit['sha']
+                print(message)
+                time = commit['commit']['committer']['date']
+                unixformattime = convert_date_time_to_timestamp(time)
+                print(unixformattime)
+                metric.add_metric([repo, commit_hash], unixformattime)
+            yield metric
+
+def convert_date_time_to_timestamp(date_time):
+    timestamp = datetime.strptime(date_time, '%Y-%m-%dT%H:%M:%SZ')
+    unixformattime = (timestamp - datetime(1970, 1, 1)).total_seconds()
+    return unixformattime
+
+def generate_urls(repos):
+    prefix = "https://api.github.com/repos/"
+    suffix = "/commits"
+    repos_urls = [ prefix+repo.strip()+suffix for repo in repos ]
+    return repos_urls
+
+
+if __name__ == "__main__":
+    username = os.environ.get('GITHUB_USER')
+    token = os.environ.get('GITHUB_TOKEN')
+    repos = os.environ.get('GITHUB_REPOS').split(',')
+    REGISTRY.register(CommitCollector(username, token, repos))
+    start_http_server(9118)
+    while True: time.sleep(1)
+

--- a/metrics-exporters/commit-time-exporter/requirements.txt
+++ b/metrics-exporters/commit-time-exporter/requirements.txt
@@ -1,0 +1,2 @@
+requests
+prometheus_client


### PR DESCRIPTION
This is a sample metrics that pulls commit time and export so Prometheus can be configured to pull the data from /metrics.
The data will have labels for commit hash and repository name.
The application is expecting 3 environment variables:
- GITHUB_USER: Github User name
- GITHUB_TOKEN: Github API token
- GITHUB_REPOS: comma separated list of repositories
Example to run the app:
```
oc new-app https://github.com/AlyIbrahim/mdt-quickstart.git#metrics-exporters --context-dir=metrics-exporters/commit-time-exporter --name=commits -e GITHUB_USER=$GITHUB_USER -e GITHUB_TOKEN=$GITHUB_TOKEN -e GITHUB_REPOS="redhat-cop/mdt-quickstart, AlyIbrahim/bitbucket-client" --name commit-exporter
oc expose svc commit-exporter
```
@etsauer 